### PR TITLE
Fix issue with graph scaling

### DIFF
--- a/lib/src/real_time_chart.dart
+++ b/lib/src/real_time_chart.dart
@@ -428,7 +428,7 @@ class _LineGraphPainter extends CustomPainter {
       final minY = data.map((point) => point.y).reduce(min);
 
       // Calculate the scaling factor for the y values
-      double yScale = 1;
+      double yScale = size.height / 10;
       final yTranslation =
           supportNegativeValuesDisplay ? size.height / 2 : size.height;
       if (maxY.abs() > yTranslation) {


### PR DESCRIPTION
On certain devices (Tab A 2019), the graph does not scale correctly unless the graph height is at 100%. This seems to fix that issue.

This issue does not occur on all devices (tested on a Google Pixel 6a without issues) but this change fixes affected devices.